### PR TITLE
Fix reload starting inbetween firing

### DIFF
--- a/Player/Weapons/Weapon.Reload.cs
+++ b/Player/Weapons/Weapon.Reload.cs
@@ -139,7 +139,7 @@ partial class SDKWeapon
 			return false;
 
 		// We're not done shooting yet.
-		if ( NextAttackTime >= Time.Now )
+		if ( NextPrimaryAttackTime >= Time.Now )
 			return false;
 
 		return true;


### PR DESCRIPTION
- Replaced NextAttackTime with NextPrimaryAttackTime

NextAttackTime is set on OnDeploy() and then never updated again under normal gameplay. Only exception to this is airblast. NextAttackTime will always be true after deploying.

Tested with all weapons.

https://user-images.githubusercontent.com/91832803/203079283-1846c47e-6963-4d55-b544-cef8d39947af.mp4


https://user-images.githubusercontent.com/91832803/203079300-073c4bf4-e8c3-4ec3-8fef-6bcde17d73c3.mp4
