### PR TITLE
Fix sniper rifle zoom animation starting from 0 fov

### DIFF
--- a/Player/Player.Camera.FOV.cs
+++ b/Player/Player.Camera.FOV.cs
@@ -9,8 +9,6 @@ namespace Amper.FPS;
 
 public partial class SDKPlayer
 {
-	protected float LastFieldOfView { get; set; }
-
 	protected float DesiredFieldOfView { get; private set; }
 	protected float LastDesiredFieldOfView { get; private set; }
 	protected float FieldOfViewChangeTime { get; private set; }
@@ -37,7 +35,7 @@ public partial class SDKPlayer
 		{
 			// If our fov change time is set to something, but we've already reached out desired FOV, then reset the speed to zero.
 			// We will be changing fov instantly until we're set speed again.
-			if ( LastFieldOfView == DesiredFieldOfView && ForcedFieldOfViewChangeTime > 0 )
+			if ( Camera.FieldOfView == DesiredFieldOfView && ForcedFieldOfViewChangeTime > 0 )
 				ForcedFieldOfViewChangeTime = 0;
 
 			FieldOfViewChangeTime = ForcedFieldOfViewChangeTime;
@@ -92,7 +90,7 @@ public partial class SDKPlayer
 	{
 		DebugOverlay.ScreenText(
 			$"[FOV]\n" +
-			$"Last Value            {LastFieldOfView}\n" +
+			$"Last Value            {LastDesiredFieldOfView}\n" +
 			$"Desired               {DesiredFieldOfView}\n" +
 			$"Change Time           {FieldOfViewChangeTime}\n" +
 			$"Animate Start         {FieldOfViewAnimateStart}\n" +

--- a/Player/Player.Camera.FOV.cs
+++ b/Player/Player.Camera.FOV.cs
@@ -56,7 +56,7 @@ public partial class SDKPlayer
 
 		if ( ForcedFieldOfViewStartWith.HasValue )
 		{
-			LastFieldOfView = ForcedFieldOfViewStartWith.Value;
+			LastDesiredFieldOfView = ForcedFieldOfViewStartWith.Value;
 			ForcedFieldOfViewStartWith = null;
 		}
 
@@ -65,7 +65,7 @@ public partial class SDKPlayer
 
 		if ( LastDesiredFieldOfView != DesiredFieldOfView )
 		{
-			FieldOfViewAnimateStart = LastFieldOfView;
+			FieldOfViewAnimateStart = LastDesiredFieldOfView;
 			TimeSinceFieldOfViewAnimateStart = 0;
 		}
 


### PR DESCRIPTION
<!-- =============== READ ME BEFORE DOING ANYTHING ELSE =============== -->
<!-- PRs must have any revelant issues or discussions linked -->
<!-- PRs must first be merged against the dev branch unless otherwise specified by the developers -->
<!-- PRs that do not follow our PR Guidelines will not be accepted -->

# Changes

- Fix FieldOfViewAnimatedStart always being 0
- Fix ForcedFieldOfViewChangeTime not resetting when reaching desired FOV
- Remove LastFieldOfView ( LastDesiredFieldOfView already fills this role )